### PR TITLE
TECH-210: Update graphql import-package version range

### DIFF
--- a/jahia-mfa-core/pom.xml
+++ b/jahia-mfa-core/pom.xml
@@ -19,6 +19,8 @@
         <jahia-depends>default, graphql-dxm-provider</jahia-depends>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-module-signature>MCwCFAOgwc31R/4eu/5ldv+haSLaqgldAhRr7L3zyibsIpc3860gXlrvt4AxMg==</jahia-module-signature>
+        <import-package>graphql.annotations.annotationTypes;version="[6.1,9)"</import-package>
+        <jahia.plugin.version>5.17-SNAPSHOT</jahia.plugin.version>
     </properties>
     
     <scm>
@@ -38,18 +40,6 @@
             <groupId>org.jahia.server</groupId>
             <artifactId>jahia-taglib</artifactId>
             <version>8.0.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java</artifactId>
-            <version>${graphql-java.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java-servlet</artifactId>
-            <version>${graphql-java-servlet.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jahia.modules</groupId>

--- a/jahia-mfa-otp-components/app/package.json
+++ b/jahia-mfa-otp-components/app/package.json
@@ -52,6 +52,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^7.0.0",
     "eslint-plugin-json": "^2.1.2",
+    "file-loader": "^6.2.0",
     "graphql": "^15.4.0",
     "react-scripts": "^4.0.1",
     "webpack-cli": "^4.2.0"

--- a/jahia-mfa-otp-provider/pom.xml
+++ b/jahia-mfa-otp-provider/pom.xml
@@ -17,6 +17,8 @@
         <jahia-depends>default, graphql-dxm-provider, jahia-mfa-core</jahia-depends>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-module-signature>MC0CFQCGEYFWVKocV4UXiBpabgo9VauJ/QIUSldapWlv0LLhoh38E/TjzoAa0+I=</jahia-module-signature>
+        <import-package>graphql.annotations.annotationTypes;version="[6.1,9)"</import-package>
+        <jahia.plugin.version>5.17-SNAPSHOT</jahia.plugin.version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:Jahia/jahia-mfa.git</connection>
@@ -63,21 +65,9 @@
             <version>3.3.0</version>
         </dependency>
         <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java</artifactId>
-            <version>${graphql-java.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.github.graphql-java</groupId>
             <artifactId>graphql-java-annotations</artifactId>
             <version>${graphql-java-annotations.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graphql-java</groupId>
-            <artifactId>graphql-java-servlet</artifactId>
-            <version>${graphql-java-servlet.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-210

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Update graphql import-package version range (and removed unused pom dependencies)
*  Also added file-loader dev dependency on jahia-mfa-otp-components as I was getting error on mvn build : 
```[INFO] ERROR in ./node_modules/@jahia/moonstone/dist/globals.css (./node_modules/css-loader/dist/cjs.js!./node_modules/@jahia/moonstone/dist/globals.css) 8:0-91
[INFO] Module not found: Error: Can't resolve 'file-loader' in '/Users/gflores/git/jahia-mfa-2/jahia-mfa-otp-components/app'
[INFO]  @ ./node_modules/@jahia/moonstone/dist/globals.css 2:12-82 9:17-24 13:15-29
[INFO]  @ ./node_modules/@jahia/moonstone/dist/components/GlobalStyle/GlobalStyle.js 2:0-27
[INFO]  @ ./node_modules/@jahia/moonstone/dist/components/GlobalStyle/index.js 1:0-30 1:0-30
[INFO]  @ ./node_modules/@jahia/moonstone/dist/components/index.js 10:0-30 10:0-30
[INFO]  @ ./node_modules/@jahia/moonstone/dist/main.js 2:0-29 2:0-29
[INFO]  @ ./node_modules/@jahia/moonstone/dist/index.js 1:0-23 1:0-23
[INFO]  @ ./src/App.jsx 6:0-47 25:38-49
[INFO]  @ ./src/index.js 4:0-24 7:36-39```